### PR TITLE
Show compilation errors in the tests to student

### DIFF
--- a/run
+++ b/run
@@ -245,9 +245,9 @@ jar -cf "judge.jar" -C /tmp/build .
 # Compiling the tests
 if ! find "$resources" -name '*.java' | xargs javac -cp ".:${resources}:${worklibs}:${testlibs}:judge.jar" -d . -sourcepath "$resources" > "$compilation" 2>&1; then
     compilation_failed "$compilation" \
-        'Er ging iets mis tijdens het compileren van de testen voor deze oefening. Contacteer je lesgever.' \
+        'Er ging iets mis tijdens het compileren van de testen voor deze oefening.' \
         'Fout in de testen' \
-        'staff'
+        'student'
 fi
 
 # Everything is compiled


### PR DESCRIPTION
By request of Pieter Goetschalckx. He convinced me most of these errors
would be due to the students (and fixable by the students), anyway.
If it's actually a compilation error in the teacher code, it'll occur
always so the teacher should correct it when creating the exercise.