### PR TITLE
Check if the correct class is submitted by using it

### DIFF
--- a/run
+++ b/run
@@ -3,11 +3,12 @@
 set -e
 
 # Temp files
-config="$(mktemp)"      # configuration
-compilation="$(mktemp)" # output of compilation
-mkdir "/tmp/build"      # compilation directory
+config="$(mktemp)"                     # configuration
+compilation="$(mktemp)"                # output of compilation
+importclass="$(mktemp ImportXXX.java)" # to check imports
+mkdir "/tmp/build"                     # compilation directory
 
-trap "rm -rf '$config' '$compilation' '/tmp/build'" EXIT
+trap "rm -rf '$config' '$compilation' '$importclass' '/tmp/build'" EXIT
 
 # Saving the configuration from stdin
 cat > "$config"
@@ -184,10 +185,6 @@ compilation_failed() {
 
     dodona append-message -f callout -d "$(printf "$callout" "$described_both_count")"
 
-    if grep -q '^package' "$filename"; then
-        dodona append-message -f callout -d 'Ben je zeker dat je de ingediende klasse in het default package plaatste?'
-    fi
-
     # Append a (failed) testcase per compilation error
     sed 's_.*/\([^/]*.java\)_\1_' "$compilation" | parse_compilation_errors "$target"
 
@@ -226,8 +223,16 @@ if ! javac -cp ".:${worklibs}" -Xlint:all $compile_opt "$filename" > "$compilati
 fi
 
 # Verify the student submitted the requested class
-if ! [ -f "${filename%.java}.class" ]; then
+cat > "$importclass" <<HERE
+public class ${importclass%.java} {
+    Class<?> userclass = ${filename%.java}.class;
+}
+HERE
+if ! javac -cp . "$importclass"; then
     dodona start-context -f plain -d "Je diende geen ${filename%.java}-klasse in, waardoor de testen niet uitgevoerd kunnen worden."
+    if grep -q '^package' "$filename"; then
+        dodona append-message -f callout -d 'Ben je zeker dat je de ingediende klasse in het default package plaatste?'
+    fi
     dodona close-context -A
     dodona close-tab
     dodona close-judgement -A -e 'compilation error' -h 'Compilatiefout'


### PR DESCRIPTION
Probably the best way to check if we can use the class of the student in
the test, is using it in the tests. This commit adds a simple test which
does just that. There's only a single reason this test could fail, which
simplifies reporting on it. If importing the class in this test works,
we can assume it will in future tests.

Also removes some unused temporary files.