### PR TITLE
Update Java version to 21

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "judge": "java",
-    "image": "dodona-java17"
+    "image": "dodona-java21"
 }

--- a/run
+++ b/run
@@ -259,6 +259,6 @@ fi
 dodona close-tab
 
 # Running the tests
-java -Xmx"${memory_limit}k" -cp ".:${worklibs}:${testlibs}:judge.jar:${resources}/properties" -Ddodona.language="${natural_language}" -Ddodona.output_cutoff="${generated_output_cutoff}" dodona.junit.JUnitJSON
+java -Djava.security.manager=allow -Xmx"${memory_limit}k" -cp ".:${worklibs}:${testlibs}:judge.jar:${resources}/properties" -Ddodona.language="${natural_language}" -Ddodona.output_cutoff="${generated_output_cutoff}" dodona.junit.JUnitJSON
 
 dodona close-judgement

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# Test this Judge by running the integration tests in the docker image
+image="dodona-java21:latest"
+
+docker run \
+    --mount type=bind,source=$PWD,destination=/home/runner/workdir,readonly \
+    "$image" \
+    -- ./integration-tests/run


### PR DESCRIPTION
- This PR updates references to Java 17 to 21
- This PR adds `-Djava.security.manager=allow` to the JVM options to allow usage of the the deprecated security manager API (see #55)
-  This PR adds a script `test.sh` which runs the integration tests within the specified docker to validate that that docker works as expected