### PR TITLE
Use the renamed dodona-java image, and use it for CI tests too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "02:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 99
+    commit-message:
+      prefix: ""
+    labels:
+      - "dependencies"

--- a/.github/test.dockerfile
+++ b/.github/test.dockerfile
@@ -1,0 +1,10 @@
+# Image used to run the integration tests in CI.
+#
+# The judge runs on the dodona-java image (published by dodona-edu/docker-images),
+# which is a minimal Alpine shipping only what the judge needs at runtime. The
+# test harness (integration-tests/run) additionally needs bash, so we layer it on
+# here rather than bloating the published image. See dodona-edu/dodona#7583.
+FROM ghcr.io/dodona-edu/dodona-java:latest
+USER root
+RUN apk add --no-cache bash
+USER runner

--- a/.github/test.dockerfile
+++ b/.github/test.dockerfile
@@ -1,9 +1,3 @@
-# Image used to run the integration tests in CI.
-#
-# The judge runs on the dodona-java image (published by dodona-edu/docker-images),
-# which is a minimal Alpine shipping only what the judge needs at runtime. The
-# test harness (integration-tests/run) additionally needs bash, so we layer it on
-# here rather than bloating the published image. See dodona-edu/dodona#7583.
 FROM ghcr.io/dodona-edu/dodona-java:latest
 USER root
 RUN apk add --no-cache bash

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,13 +7,9 @@ jobs:
   example-exercises:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-
-    # Run the integration tests on the actual judge image (see
-    # .github/test.dockerfile), so CI uses the same Java runtime as production.
+    - uses: actions/checkout@v7
     - name: Build the judge test image
       run: docker build --tag dodona-java-test --file .github/test.dockerfile .
-
     - name: Evaluate sample exercises on the judge image
       run: |
         docker run --rm \

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Evaluate sample exercises on the judge image
       run: |
         docker run --rm \
-          --volume "$PWD":/judge \
+          --volume "$PWD":/judge:ro \
           --workdir /judge \
           dodona-java-test \
           ./integration-tests/run

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -6,12 +6,26 @@ on:
 jobs:
   example-exercises:
     runs-on: ubuntu-latest
-    container:
-      image: eclipse-temurin:25
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Install dependencies
-      run: apt update && apt install -y jq
-    - name: Evaluate sample exercises
-      run: ./integration-tests/run
+    - uses: actions/checkout@v4
+
+    # Run the integration tests on the actual judge image, so CI uses the same
+    # Java runtime as production. The image is a minimal Alpine that only ships
+    # what the judge needs at runtime, so we layer on the test harness's extra
+    # dependency (bash) here rather than bloating the published image.
+    - name: Build the judge image with the test harness's dependencies
+      run: |
+        docker build --tag dodona-java-test - <<'DOCKERFILE'
+        FROM ghcr.io/dodona-edu/dodona-java:latest
+        USER root
+        RUN apk add --no-cache bash
+        USER runner
+        DOCKERFILE
+
+    - name: Evaluate sample exercises on the judge image
+      run: |
+        docker run --rm \
+          --volume "$PWD":/judge \
+          --workdir /judge \
+          dodona-java-test \
+          ./integration-tests/run

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -7,7 +7,7 @@ jobs:
   example-exercises:
     runs-on: ubuntu-latest
     container:
-      image: eclipse-temurin:21
+      image: eclipse-temurin:25
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -9,18 +9,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Run the integration tests on the actual judge image, so CI uses the same
-    # Java runtime as production. The image is a minimal Alpine that only ships
-    # what the judge needs at runtime, so we layer on the test harness's extra
-    # dependency (bash) here rather than bloating the published image.
-    - name: Build the judge image with the test harness's dependencies
-      run: |
-        docker build --tag dodona-java-test - <<'DOCKERFILE'
-        FROM ghcr.io/dodona-edu/dodona-java:latest
-        USER root
-        RUN apk add --no-cache bash
-        USER runner
-        DOCKERFILE
+    # Run the integration tests on the actual judge image (see
+    # .github/test.dockerfile), so CI uses the same Java runtime as production.
+    - name: Build the judge test image
+      run: docker build --tag dodona-java-test --file .github/test.dockerfile .
 
     - name: Evaluate sample exercises on the judge image
       run: |

--- a/config.json
+++ b/config.json
@@ -1,4 +1,3 @@
 {
-    "judge": "java",
-    "image": "dodona-java"
+    "judge": "java"
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "judge": "java",
-    "image": "dodona-java21"
+    "image": "dodona-java"
 }

--- a/integration-tests/junit6/timeout/result.json
+++ b/integration-tests/junit6/timeout/result.json
@@ -32,8 +32,8 @@
 {
   "command": "escalate-status",
   "status": {
-    "enum": "runtime error",
-    "human": "Runtime error"
+    "enum": "time limit exceeded",
+    "human": "Time limit exceeded"
   }
 }
 {

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Test this Judge by running the integration tests in the docker image
-image="dodona/dodona-java21:latest"
+image="ghcr.io/dodona-edu/dodona-java:latest"
 
 docker run \
     --mount type=bind,source=$PWD,destination=/home/runner/workdir,readonly \

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
-# Test this Judge by running the integration tests in the docker image
-image="ghcr.io/dodona-edu/dodona-java:latest"
-
-docker run \
-    --mount type=bind,source=$PWD,destination=/home/runner/workdir,readonly \
-    "$image" \
-    -- ./integration-tests/run -v
+# Test this judge by running the integration tests in the judge image, same as CI.
+docker build --tag dodona-java-test --file .github/test.dockerfile .
+docker run --rm \
+    --volume "$PWD":/judge:ro \
+    --workdir /judge \
+    dodona-java-test \
+    ./integration-tests/run -v


### PR DESCRIPTION
Part of the `java21` → `java` image rename (dodona-edu/dodona#7583). Phase 2: point the judge at the renamed `dodona-java` image, and run CI on that actual image, part of dodona-edu/dodona#7583.

Specificially:
- `config.json`: removed the dead `image` field
- `test.sh` now builds on the actual image so we can verify our changes on what's live on production right now
- the integration test is now also corrected (was pushed to main in 477a9d429a9d398ff4d7b839956adb689acdbc41, but broke the pipeline there)
- and while we're at it, add a dependabot action to keep the actions up to date

<details>

## What changed
- `config.json`: removed the `image` field (it's dead, see note below).
- `test.sh`: `dodona/dodona-java21:latest` → `ghcr.io/dodona-edu/dodona-java:latest`.
- CI (`.github/workflows/java.yml`) now runs the integration tests on the actual judge image instead of a separate `eclipse-temurin` pin, built from `.github/test.dockerfile`.
- `integration-tests/junit6/timeout/result.json`: regenerated to fix a pre-existing master CI failure (see below).

## Why run CI on our own image
The workflow pinned `eclipse-temurin:21` while the judge actually runs on Java 25, so CI was a version behind. Running on the real image keeps them in lockstep. That image is a deliberately minimal Alpine (just JDK + jq, runs as `runner`), so `.github/test.dockerfile` layers on the one extra thing the bash test harness needs (`bash`). Checkout runs on the host, so the image itself needs no node/git.

## The junit6/timeout result update
Not caused by the rename: judge commit 477a9d4 ("Identify TimeoutExeption correctly") broadened the timeout classification to also catch `java.util.concurrent.TimeoutException` (what JUnit Jupiter's `@Timeout` throws), so it's now `time limit exceeded` instead of the old generic `runtime error` (accepted/failed unchanged). The `junit6/timeout` fixture was never regenerated, so master CI had been red since then; this regenerates it. It was the only affected test.

## Why test.sh switched registry
The old Docker Hub `dodona/dodona-java21:latest` was last pushed 2025-08-19 (pre-Java-25); the live images are on GHCR. A plain rename to `dodona/dodona-java` would point at the old legacy image, so I pointed it at GHCR.

## Verify
- CI `Java` workflow builds `.github/test.dockerfile` and runs the integration tests on `dodona-java` (Java 25).
- `./test.sh` pulls `ghcr.io/dodona-edu/dodona-java:latest` and runs the tests locally.

The production judge image (dodona DB) is switched separately and manually, after the image is on the workers.

> Note: dodona never reads a judge's `config.json` `image` (it uses `judges.image` from the DB / the exercise evaluation config), so the field was dead; removed it here too, matching judge-markdown#5.

</details>
